### PR TITLE
Add recent publications and AlphaMapleSAT solver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,4 +34,5 @@ gem "wdm", "~> 0.1.0", :install_if => Gem.win_platform?
 # kramdown v2 ships without the gfm parser by default. If you're using
 # kramdown v1, comment out this line.
 gem "kramdown-parser-gfm"
+gem "webrick"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
     wdm (0.1.1)
+    webrick (1.9.2)
 
 PLATFORMS
   ruby
@@ -79,6 +80,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.0)
+  webrick
 
 BUNDLED WITH
-   2.0.2
+   2.6.9

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,3 +1,22 @@
+- title: "Understanding CDCL Solvers via Scalability Studies and Proofdoors"
+  authors: Shimin Zhang, Yechuan Xia, Chunxiao Li, Jianwen Li, Moshe Y. Vardi, Vijay Ganesh
+  pdf: https://arxiv.org/abs/2605.15506
+- title: "Proofdoors and Efficiency of CDCL Solvers"
+  authors: Sunidhi Singh, Vincent Liew, Marc Vinyals, Vijay Ganesh
+  pdf: https://arxiv.org/abs/2603.26286
+- title: "AlphaMapleSAT: An MCTS-based Cube-and-Conquer SAT Solver for Hard Combinatorial Problems"
+  authors: Piyush Jha, Zhengyu Li, Zhiwei Lu, Curtis Bright, Vijay Ganesh
+  pdf: https://arxiv.org/abs/2401.13770
+  bib: https://dblp.uni-trier.de/rec/journals/corr/abs-2401-13770.html?view=bibtex
+- title: "A Reinforcement Learning Based Reset Policy for CDCL SAT Solvers"
+  authors: Chunxiao Li, Chuan Liu, Jonathan Chung, Zhiwei Lu, Piyush Jha, Vijay Ganesh
+  pdf: https://arxiv.org/abs/2404.03753
+  bib: https://dblp.uni-trier.de/rec/journals/corr/abs-2404-03753.html?view=bibtex
+- title: "Limits of CDCL Learning via Merge Resolution"
+  authors: Marc Vinyals, Chunxiao Li, Noah Fleming, Antonina Kolokolova, Vijay Ganesh
+  pub-type: 26th International Conference on Theory and Applications of Satisfiability Testing (**SAT 2023**)
+  pdf: https://arxiv.org/abs/2304.09422
+  bib: https://dblp.uni-trier.de/rec/conf/sat/Vinyals0FKG23.html?view=bibtex
 - title: MapleSSV SAT Solver for SAT Competition 2021
   authors: Saeed Nejati, Md Solimul Chowdhury, Vijay Ganesh
   pub-type: Solver Description, SAT competition 2021

--- a/solvers.md
+++ b/solvers.md
@@ -4,6 +4,45 @@ script: assets/js/collapsibles.js
 ---
 
 # Solvers
+## AlphaMapleSAT
+* A novel Monte Carlo Tree Search (MCTS) based Cube-and-Conquer SAT solver for hard combinatorial problems
+* Uses a deductively-driven MCTS lookahead to generate cubes; a CDCL solver handles the conquer phase
+* [See paper for details](https://arxiv.org/abs/2401.13770)
+* [GitHub repository](https://github.com/piyush-J/AlphaMapleSAT)
+
+{% capture license_title_AlphaMapleSAT %}
+See License (MIT)
+{% endcapture %}
+
+{% capture license_AlphaMapleSAT %}
+```
+AlphaMapleSAT -- Copyright (c) 2025 Piyush Jha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+{% endcapture %}
+
+{% include collapsible.html
+	title=license_title_AlphaMapleSAT
+	content=license_AlphaMapleSAT
+%}
+
 ## MapleCOMSPS, MapleCOMSPS_LRB, and MapleCOMSPS_CHB
 * MapleCOMSPS won 1st in the SAT Competition 2016 Main track and 2nd in the Application category
 * MapleCOMSPS_LRB won 1st in the SAT Competition 2016 Application category


### PR DESCRIPTION
- Add 5 recent CDCL-related papers to publications.yml (2023–2026)
- Add AlphaMapleSAT to solvers page with license