### PR TITLE
Update publications dates and add KissatEvolve, MapleCaDiCaL_PPD solvers

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,32 +1,39 @@
 - title: "Understanding CDCL Solvers via Scalability Studies and Proofdoors"
   authors: Shimin Zhang, Yechuan Xia, Chunxiao Li, Jianwen Li, Moshe Y. Vardi, Vijay Ganesh
+  date: May 15, 2026
   pdf: https://arxiv.org/abs/2605.15506
 - title: "Proofdoors and Efficiency of CDCL Solvers"
   authors: Sunidhi Singh, Vincent Liew, Marc Vinyals, Vijay Ganesh
+  pub-type: 29th International Conference on Theory and Applications of Satisfiability Testing (**SAT 2026**)
+  date: July 20, 2026
   pdf: https://arxiv.org/abs/2603.26286
 - title: "AlphaMapleSAT: An MCTS-based Cube-and-Conquer SAT Solver for Hard Combinatorial Problems"
   authors: Piyush Jha, Zhengyu Li, Zhiwei Lu, Curtis Bright, Vijay Ganesh
+  pub-type: arXiv preprint
+  date: January 24, 2024
   pdf: https://arxiv.org/abs/2401.13770
   bib: https://dblp.uni-trier.de/rec/journals/corr/abs-2401-13770.html?view=bibtex
 - title: "A Reinforcement Learning Based Reset Policy for CDCL SAT Solvers"
   authors: Chunxiao Li, Chuan Liu, Jonathan Chung, Zhiwei Lu, Piyush Jha, Vijay Ganesh
+  pub-type: arXiv preprint
+  date: April 4, 2024
   pdf: https://arxiv.org/abs/2404.03753
   bib: https://dblp.uni-trier.de/rec/journals/corr/abs-2404-03753.html?view=bibtex
 - title: "Limits of CDCL Learning via Merge Resolution"
   authors: Marc Vinyals, Chunxiao Li, Noah Fleming, Antonina Kolokolova, Vijay Ganesh
   pub-type: 26th International Conference on Theory and Applications of Satisfiability Testing (**SAT 2023**)
+  date: July 4, 2023
   pdf: https://arxiv.org/abs/2304.09422
   bib: https://dblp.uni-trier.de/rec/conf/sat/Vinyals0FKG23.html?view=bibtex
-- title: MapleSSV SAT Solver for SAT Competition 2021
-  authors: Saeed Nejati, Md Solimul Chowdhury, Vijay Ganesh
-  pub-type: Solver Description, SAT competition 2021
-  pdf: assets/MapleSSV-SATcomp21.pdf
 - title: "New Concurrent and Distributed Painless solvers: P-MCOMSPS, P-MCOMSPS-COM, P-MCOMSPS-MPI, and P-MCOMSPS-COM-MPI"
   authors: Vincent Vallade, Ludovic Le Frioux, Razvan Oanea, Souheib Baarir, Julien Sopena, Fabrice Kordon, Saeed Nejati, Vijay Ganesh
   pub-type: Solver Description, SAT competition 2021
+  date: July 5, 2021
   pdf: assets/SAT_Competition_2021-parallelSAT.pdf
 - title: On the Hierarchical Community Structure of Practical SAT Formulas
   authors: Chunxiao Li, Jonathan Chung, Soham Mukherjee, Marc Vinyals, Noah Fleming, Antonina Kolokolova, Alice Mu, and Vijay Ganesh
+  pub-type: 24th International Conference on Theory and Applications of Satisfiability Testing (**SAT 2021**)
+  date: July 5, 2021
   pdf: https://arxiv.org/abs/2103.14992
   bib: https://dblp.uni-trier.de/rec/journals/corr/abs-2103-14992.html?view=bibtex
 - title: Towards a Complexity-theoretic Understanding of Restarts in SAT solvers

--- a/solvers.md
+++ b/solvers.md
@@ -4,6 +4,88 @@ script: assets/js/collapsibles.js
 ---
 
 # Solvers
+## KissatEvolve
+* Submitted to the SAT Competition 2026
+* Based off of [Kissat](https://github.com/arminbiere/kissat), with LLM and evolutionary search to optimize various heuristics
+* [GitHub repository](https://github.com/m3ru/KissatEvolve)
+
+{% capture license_title_KissatEvolve %}
+See License (MIT)
+{% endcapture %}
+
+{% capture license_KissatEvolve %}
+```
+Copyright (c) 2021-2024 Armin Biere, University of Freiburg, Germany
+Copyright (c) 2019-2021 Armin Biere, Johannes Kepler University Linz, Austria
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+{% endcapture %}
+
+{% include collapsible.html
+	title=license_title_KissatEvolve
+	content=license_KissatEvolve
+%}
+
+## MapleCaDiCaL_PPD
+* MapleCaDiCaL_PPD won 3rd (bronze medal) in the [SAT Competition 2023](https://satcompetition.github.io/2023/) Main track
+* Based off of [CaDiCaL](https://github.com/arminbiere/cadical)
+* [See solver description in SAT Competition 2023 proceedings](https://researchportal.helsinki.fi/files/269128852/sc2023_proceedings.pdf)
+
+{% capture license_title_MapleCaDiCaL_PPD %}
+See License (MIT)
+{% endcapture %}
+
+{% capture license_MapleCaDiCaL_PPD %}
+```
+MapleCaDiCaL_PPD -- Copyright (c) 2023, Vijay Ganesh
+
+CaDiCaL -- Copyright (c) 2016-2021 Armin Biere, Johannes Kepler University Linz, Austria
+           Copyright (c) 2021-2021 Armin Biere, Albert-Ludwigs-University Freiburg, Germany
+           Copyright (c) 2020-2021 Mathias Fleury, Johannes Kepler University Linz, Austria
+           Copyright (c) 2020-2021 Nils Froleyks, Johannes Kepler University Linz, Austria
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+{% endcapture %}
+
+{% include collapsible.html
+	title=license_title_MapleCaDiCaL_PPD
+	content=license_MapleCaDiCaL_PPD
+%}
+
 ## AlphaMapleSAT
 * A novel Monte Carlo Tree Search (MCTS) based Cube-and-Conquer SAT solver for hard combinatorial problems
 * Uses a deductively-driven MCTS lookahead to generate cubes; a CDCL solver handles the conquer phase


### PR DESCRIPTION
- Add publication dates to all papers per professor feedback
- Add SAT 2026 venue to Proofdoors paper; SAT 2021 venue to Community Structure paper
- Remove MapleSSV SAT Competition 2021 entry
- Add KissatEvolve solver (SAT 2026, Kissat-based with LLM+evolutionary search)
- Add MapleCaDiCaL_PPD solver (SAT 2023 bronze medal, CaDiCaL-based)